### PR TITLE
Implement context server configuration API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde = "1.0"
-zed_extension_api = "0.2.0"
+schemars = "0.8"
+zed_extension_api = "0.5.0"

--- a/configuration/default_settings.jsonc
+++ b/configuration/default_settings.jsonc
@@ -1,0 +1,6 @@
+{
+  /// Port to use (Default: 3025, Optional)
+  // "port": 3025
+  /// Host to bind to (Default: 127.0.0.1, Optional)
+  // "host": "127.0.0.1"
+}

--- a/configuration/installation_instructions.md
+++ b/configuration/installation_instructions.md
@@ -1,0 +1,1 @@
+No configuration needed to setup the Browser Tools MCP.


### PR DESCRIPTION
Hey, in `v0.5.0` of the extension API we exposed a new interface called `ContextServerConfiguration`.
Exposing this allows the users to configure the context server in a dialog once `Install` on the Extension Page is clicked.
Support for this will land in Zed 0.186.x.
See below for an example:
<img width="671" alt="image" src="https://github.com/user-attachments/assets/0949d8b8-5358-4c43-a1a6-17173a7a36e6" />
